### PR TITLE
Fix vsgan poetry dependency

### DIFF
--- a/plugins/vsgan/default.nix
+++ b/plugins/vsgan/default.nix
@@ -3,7 +3,7 @@
 , fetchFromGitHub
 , vapoursynth
 , numpy
-, poetry
+, poetry-core
 , pytorch
 }:
 
@@ -22,7 +22,7 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [
     numpy
-    poetry
+    poetry-core
     pytorch
   ];
 


### PR DESCRIPTION
After a recent poetry update in nixpkgs, we need to depend upon poetry-core instead.