### PR TITLE
Add GitHub Workflow to test build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,8 @@
 name: Test
 on:
   pull_request:
+  schedule:
+    - cron: "0 0 1 * *"
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,16 @@
+name: Test
+on:
+  pull_request:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: cachix/install-nix-action@v22
+      with:
+        nix_path: nixpkgs=channel:nixos-unstable
+    - uses: cachix/cachix-action@v12
+      with:
+        name: nix-community
+        authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+    - run: nix-build --show-trace --argstr vs-overlay $GITHUB_WORKSPACE everything-shell.nix

--- a/everything-shell.nix
+++ b/everything-shell.nix
@@ -1,0 +1,102 @@
+# A Nix shell with VapourSynth and all plugins (from this overlay).  Used for
+# testing that all plugins in this overlay build.
+{vs-overlay}: let
+  pkgs = import <nixpkgs> {
+    config.allowUnfree = true;
+    overlays = [(import vs-overlay)];
+    # Force default Python to 3.x
+    config.packageOverrides = pkgs: {
+      python = pkgs.python3;
+    };
+  };
+in
+  # TODO: Fix broken packages, which are commented out below.
+  pkgs.mkShell {
+    packages = [
+      (pkgs.vapoursynth.withPlugins [
+        pkgs.vapoursynthPlugins.adaptivegrain
+        pkgs.vapoursynthPlugins.addgrain
+        pkgs.vapoursynthPlugins.autocrop
+        pkgs.vapoursynthPlugins.awarpsharp2
+        pkgs.vapoursynthPlugins.bestaudiosource
+        pkgs.vapoursynthPlugins.beziercurve
+        pkgs.vapoursynthPlugins.bifrost
+        pkgs.vapoursynthPlugins.bilateral
+        pkgs.vapoursynthPlugins.bm3d
+        pkgs.vapoursynthPlugins.cas
+        pkgs.vapoursynthPlugins.cnr2
+        pkgs.vapoursynthPlugins.combmask
+        pkgs.vapoursynthPlugins.continuityfixer
+        pkgs.vapoursynthPlugins.ctmf
+        # pkgs.vapoursynthPlugins.d2vsource
+        pkgs.vapoursynthPlugins.dctfilter
+        pkgs.vapoursynthPlugins.deblock
+        pkgs.vapoursynthPlugins.decross
+        pkgs.vapoursynthPlugins.descale
+        pkgs.vapoursynthPlugins.dfttest
+        pkgs.vapoursynthPlugins.eedi2
+        pkgs.vapoursynthPlugins.eedi3m
+        # pkgs.vapoursynthPlugins.f3kdb
+        pkgs.vapoursynthPlugins.ffms2
+        pkgs.vapoursynthPlugins.fft3dfilter
+        pkgs.vapoursynthPlugins.fillborders
+        pkgs.vapoursynthPlugins.fluxsmooth
+        pkgs.vapoursynthPlugins.fmtconv
+        pkgs.vapoursynthPlugins.histogram
+        pkgs.vapoursynthPlugins.hqdn3d
+        pkgs.vapoursynthPlugins.imwri
+        pkgs.vapoursynthPlugins.knlmeanscl
+        # pkgs.vapoursynthPlugins.lsmashsource
+        pkgs.vapoursynthPlugins.median
+        pkgs.vapoursynthPlugins.minideen
+        pkgs.vapoursynthPlugins.miscfilters-obsolete
+        pkgs.vapoursynthPlugins.motionmask
+        pkgs.vapoursynthPlugins.msmoosh
+        pkgs.vapoursynthPlugins.mvtools
+        pkgs.vapoursynthPlugins.nnedi3
+        pkgs.vapoursynthPlugins.nnedi3cl
+        pkgs.vapoursynthPlugins.ocr
+        # pkgs.vapoursynthPlugins.placebo
+        pkgs.vapoursynthPlugins.readmpls
+        pkgs.vapoursynthPlugins.remap
+        pkgs.vapoursynthPlugins.removegrain
+        pkgs.vapoursynthPlugins.retinex
+        pkgs.vapoursynthPlugins.sangnom
+        pkgs.vapoursynthPlugins.scxvid
+        pkgs.vapoursynthPlugins.subtext
+        pkgs.vapoursynthPlugins.tcanny
+        pkgs.vapoursynthPlugins.temporalmedian
+        pkgs.vapoursynthPlugins.temporalsoften2
+        pkgs.vapoursynthPlugins.tnlmeans
+        pkgs.vapoursynthPlugins.ttempsmooth
+        pkgs.vapoursynthPlugins.vivtc
+        # Requires non-redistributable unfree TensorRT.
+        # pkgs.vapoursynthPlugins.vstrt
+        pkgs.vapoursynthPlugins.wwxd
+        pkgs.vapoursynthPlugins.znedi3
+
+        # pkgs.vapoursynthPlugins.acsuite
+        pkgs.vapoursynthPlugins.adjust
+        pkgs.vapoursynthPlugins.astdr
+        # pkgs.vapoursynthPlugins.awsmfunc
+        # pkgs.vapoursynthPlugins.debandshit
+        pkgs.vapoursynthPlugins.dfmderainbow
+        pkgs.vapoursynthPlugins.edi_rpow2
+        pkgs.vapoursynthPlugins.finedehalo
+        pkgs.vapoursynthPlugins.fvsfunc
+        pkgs.vapoursynthPlugins.havsfunc
+        pkgs.vapoursynthPlugins.kagefunc
+        # pkgs.vapoursynthPlugins.lvsfunc
+        pkgs.vapoursynthPlugins.mt_lutspa
+        pkgs.vapoursynthPlugins.muvsfunc
+        pkgs.vapoursynthPlugins.mvsfunc
+        pkgs.vapoursynthPlugins.nnedi3_resample
+        pkgs.vapoursynthPlugins.nnedi3_rpow2
+        # pkgs.vapoursynthPlugins.rekt
+        # pkgs.vapoursynthPlugins.vardefunc
+        # pkgs.vapoursynthPlugins.vsTAAmbk
+        pkgs.vapoursynthPlugins.vsgan
+        pkgs.vapoursynthPlugins.vsutil
+      ])
+    ];
+  }

--- a/test-build.sh
+++ b/test-build.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+nix-build --show-trace --argstr vs-overlay $PWD everything-shell.nix


### PR DESCRIPTION
To guard against build-breaking regressions, introduce a GitHub Workflow that builds VapourSynth with all plugins from this overlay.

Some plugins are presently broken, so they are commented out until they are fixed.