### PR TITLE
Fix awsmfunc build

### DIFF
--- a/everything-shell.nix
+++ b/everything-shell.nix
@@ -56,7 +56,7 @@ in
         pkgs.vapoursynthPlugins.nnedi3
         pkgs.vapoursynthPlugins.nnedi3cl
         pkgs.vapoursynthPlugins.ocr
-        # pkgs.vapoursynthPlugins.placebo
+        pkgs.vapoursynthPlugins.placebo
         pkgs.vapoursynthPlugins.readmpls
         pkgs.vapoursynthPlugins.remap
         pkgs.vapoursynthPlugins.removegrain
@@ -78,7 +78,7 @@ in
         # pkgs.vapoursynthPlugins.acsuite
         pkgs.vapoursynthPlugins.adjust
         pkgs.vapoursynthPlugins.astdr
-        # pkgs.vapoursynthPlugins.awsmfunc
+        pkgs.vapoursynthPlugins.awsmfunc
         # pkgs.vapoursynthPlugins.debandshit
         pkgs.vapoursynthPlugins.dfmderainbow
         pkgs.vapoursynthPlugins.edi_rpow2
@@ -92,7 +92,7 @@ in
         pkgs.vapoursynthPlugins.mvsfunc
         pkgs.vapoursynthPlugins.nnedi3_resample
         pkgs.vapoursynthPlugins.nnedi3_rpow2
-        # pkgs.vapoursynthPlugins.rekt
+        pkgs.vapoursynthPlugins.rekt
         # pkgs.vapoursynthPlugins.vardefunc
         # pkgs.vapoursynthPlugins.vsTAAmbk
         pkgs.vapoursynthPlugins.vsgan

--- a/plugins/awsmfunc/default.nix
+++ b/plugins/awsmfunc/default.nix
@@ -1,4 +1,4 @@
-{ lib, vapoursynthPlugins, buildPythonPackage, fetchgit, numpy, vapoursynth }:
+{ lib, vapoursynthPlugins, buildPythonPackage, setuptools, fetchFromGitHub, numpy, vapoursynth }:
 let
   propagatedBinaryPlugins = with vapoursynthPlugins; [
     descale
@@ -9,23 +9,18 @@ let
 in
 buildPythonPackage rec {
   pname = "awsmfunc";
-  version = "unstable-2021-01-26";
+  version = "1.3.4";
+  pyproject = true;
 
-  src = fetchgit {
-    url = "https://git.concertos.live/AHD/awsmfunc.git";
-    rev = "e57ad6a976d059ffcf8ae59ee986bdbefef53cd0";
-    sha256 = "0j2gzxcz3sy0h7r5a1dhl6xjgjd2m66mw4kfm8q2glar5b7gn0k7";
+  src = fetchFromGitHub {
+    owner = "OpusGang";
+    repo = pname;
+    rev = version;
+    hash = "sha256-7J7s/SdnA5/A/q4SaBfIWG+qOwHpjSrUzWkY1r63wwc=";
   };
 
-  # This does not depend on vapoursynth (since this is used from within
-  # vapoursynth).
-  postPatch = ''
-    substituteInPlace requirements.txt \
-        --replace "VapourSynth>=49" "" \
-        --replace "rekt@https://gitlab.com/Ututu/rekt/-/archive/3da2b2f2b2d670e635cef6dcc61f19c8fe10f1fa/rekt-3da2b2f2b2d670e635cef6dcc61f19c8fe10f1fa.zip" "rekt"
-  '';
-
   propagatedBuildInputs = [
+    setuptools
     numpy
   ] ++ (with vapoursynthPlugins; [
     rekt
@@ -37,8 +32,8 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "A VapourSynth function collection";
-    homepage = "https://git.concertos.live/AHD/awsmfunc";
-    license = licenses.unfree; # no license
+    homepage = "https://github.com/OpusGang/awsmfunc";
+    license = licenses.mit;
     maintainers = with maintainers; [ sbruder ];
     platforms = platforms.all;
   };

--- a/plugins/placebo/default.nix
+++ b/plugins/placebo/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "vs-placebo";
-  version = "1.4.2";
+  version = "1.4.4";
 
   src = fetchFromGitHub {
     owner = "Lypheo";
     repo = pname;
     rev = version;
-    sha256 = "sha256-nerS1z/Ch/UqcmcY2gNL1Xl3hs1/etEAODj8pzrSuEE=";
+    sha256 = "sha256-1DTdllP+Y4s+t2PMnpcgeLjOxOyyV/yhFSxPP9/Gy9M=";
     fetchSubmodules = true;
   };
 
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
 
   postPatch = ''
     substituteInPlace meson.build \
-        --replace "vapoursynth_dep.get_pkgconfig_variable('libdir')" "get_option('libdir')"
+        --replace "vapoursynth_dep.get_variable(pkgconfig: 'libdir')" "get_option('libdir')"
   '';
 
   meta = with lib; {

--- a/plugins/rekt/default.nix
+++ b/plugins/rekt/default.nix
@@ -1,40 +1,29 @@
-{ lib, buildPythonPackage, fetchFromGitLab, vapoursynthPlugins, vapoursynth }:
+{ lib, buildPythonPackage, setuptools, fetchFromGitHub, vapoursynthPlugins, vapoursynth }:
 
 buildPythonPackage rec {
   pname = "rekt";
-  version = "39";
+  version = "1.0.0";
+  pyproject = true;
 
-  src = fetchFromGitLab {
-    owner = "Ututu";
+  src = fetchFromGitHub {
+    owner = "OpusGang";
     repo = pname;
-    rev = "153863e07779219c48cf1223bfdba86c47bc43be";
-    sha256 = "1h83dqwn71pfqxx8hppbqc7i9mh0a2pbpydsm8jvf538z9nr2sl9";
+    rev = version;
+    sha256 = "sha256-SWu7W0DFoPLeTe4+aYQGUlaU0n63W3IB7Fdi71uqyzw=";
   };
 
-  # This does not depend on vapoursynth (since this is used from within
-  # vapoursynth).
-  postPatch = ''
-    substituteInPlace setup.py \
-        --replace "install_requires=['vapoursynth', " "install_requires=["
-  '';
-
-  propagatedBuildInputs = with vapoursynthPlugins; [
-    vsutil
+  propagatedBuildInputs = [
+    setuptools
+    vapoursynthPlugins.vsutil
   ];
 
   checkInputs = [ vapoursynth ];
-  checkPhase = ''
-    runHook preCheck
-    # This overrides the default setuptools checkPhase that detects tests (that
-    # don’t work) even though this package doesn’t have tests.
-    runHook postCheck
-  '';
   pythonImportsCheck = [ "rekt" ];
 
   meta = with lib; {
     description = "VapourSynth wrapper for Cropping and Stacking clips";
-    homepage = "https://gitlab.com/Ututu/rekt";
-    license = licenses.unfree; # no license
+    homepage = "https://github.com/OpusGang/rekt";
+    license = licenses.mit;
     maintainers = with maintainers; [ sbruder ];
     platforms = platforms.all;
   };


### PR DESCRIPTION
Update `awsmfunc` and dependencies `rekt` and `placebo`.

Note that `awsmfunc` and `rekt` upstream repos have moved.

Closes #19.