### PR TITLE
f3kdb: flash3kyuu_deband -> neo_f3kdb

### DIFF
--- a/everything-shell.nix
+++ b/everything-shell.nix
@@ -36,7 +36,7 @@ in
         pkgs.vapoursynthPlugins.dfttest
         pkgs.vapoursynthPlugins.eedi2
         pkgs.vapoursynthPlugins.eedi3m
-        # pkgs.vapoursynthPlugins.f3kdb
+        pkgs.vapoursynthPlugins.f3kdb
         pkgs.vapoursynthPlugins.ffms2
         pkgs.vapoursynthPlugins.fft3dfilter
         pkgs.vapoursynthPlugins.fillborders

--- a/plugins/f3kdb/default.nix
+++ b/plugins/f3kdb/default.nix
@@ -1,26 +1,40 @@
-{ lib, stdenv, fetchFromGitHub, wafHook, python3, vapoursynth }:
+{ lib, stdenv, fetchFromGitHub, cmake, pkg-config, python3, vapoursynth, tbb }:
 
-stdenv.mkDerivation rec {
-  pname = "flash3kyuu_deband";
-  version = "unstable-2018-08-09";
+stdenv.mkDerivation (finalAttrs: {
+  pname = "neo_f3kdb";
+  version = "r9";
 
   src = fetchFromGitHub {
-    owner = "SAPikachu";
-    repo = pname;
-    rev = "c57e9d6a535ec9a85fb5415a405f099cbe69f535";
-    sha256 = "1jkp6b29adjfwl94r8snvk4fv2vy0rgvswsyda5f4jb3lf9hds59";
+    owner = "HomeOfAviSynthPlusEvolution";
+    repo = finalAttrs.pname;
+    rev = finalAttrs.version;
+    sha256 = "sha256-MIvKjsemDeyv9qonuJbns0Dau8BjFQ1REppccs7s9JU=";
   };
 
-  wafConfigureFlags = [ "--libdir=${placeholder "out"}/lib/vapoursynth" ];
+  patches = [
+    ./no-git.patch
+  ];
 
-  nativeBuildInputs = [ wafHook python3 ];
-  buildInputs = [ vapoursynth ];
+  nativeBuildInputs = [ cmake pkg-config python3 ];
+  buildInputs = [ vapoursynth tbb ];
+
+  cmakeFlags = [
+    "-DVERSION=${finalAttrs.version}"
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -D --target-directory="$out/lib/vapoursynth" *.so
+
+    runHook postInstall
+  '';
 
   meta = with lib; {
     description = "A deband library and filter for AviSynth/VapourSynth";
-    homepage = "https://github.com/SAPikachu/flash3kyuu_deband";
+    homepage = "https://github.com/HomeOfAviSynthPlusEvolution/neo_f3kdb";
     license = licenses.gpl3;
     maintainers = with maintainers; [ tadeokondrak ];
     platforms = platforms.all;
   };
-}
+})

--- a/plugins/f3kdb/no-git.patch
+++ b/plugins/f3kdb/no-git.patch
@@ -1,0 +1,15 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index f1ee4b3..2f10fb3 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -6,10 +6,6 @@ add_library(neo-f3kdb SHARED main.cpp src/version.rc ${CODE} ${CODE_IMPL})
+ set_property(TARGET neo-f3kdb PROPERTY CXX_STANDARD 17)
+ option(ENABLE_PAR "Enable C++17 Parallel Execution" ON)
+ 
+-find_package(Git REQUIRED)
+-execute_process(COMMAND ${GIT_EXECUTABLE} describe --first-parent --tags --always OUTPUT_VARIABLE GIT_REPO_VERSION OUTPUT_STRIP_TRAILING_WHITESPACE)
+-string(REGEX REPLACE "(r[0-9]+).*" "\\1" VERSION ${GIT_REPO_VERSION})
+-
+ configure_file (
+   "${PROJECT_SOURCE_DIR}/src/version.hpp.in"
+   "${PROJECT_SOURCE_DIR}/src/version.hpp"


### PR DESCRIPTION
Update `f3kdb` to the more recently-developed `neo_f3kdb` fork.  `flash3kyuu_deband` no longer builds against current `nixpkgs-unstable`, so this also fixes the plugin build.